### PR TITLE
Fix for Findmc-gol.cmake

### DIFF
--- a/ch7/part-7/cmake/Findmc-gol.cmake
+++ b/ch7/part-7/cmake/Findmc-gol.cmake
@@ -9,15 +9,22 @@ find_library(
   NAMES game-of-life game-of-lifed
   PATHS ${mc-gol_PATH}/lib)
 
+# todo - windows only
+find_file(
+  mc-gol_DLL
+  NAMES game-of-life.dll game-of-lifed.dll
+  PATHS ${mc-gol_PATH}/bin)
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(mc-gol DEFAULT_MSG mc-gol_LIBRARY
+find_package_handle_standard_args(mc-gol DEFAULT_MSG mc-gol_LIBRARY mc-gol_DLL
                                   mc-gol_INCLUDE_DIR)
 
 # if the library has been found, define the imported target
 if(mc-gol_FOUND AND NOT TARGET minimal-cmake::game-of-life)
-  add_library(minimal-cmake::game-of-life UNKNOWN IMPORTED)
+  add_library(minimal-cmake::game-of-life SHARED IMPORTED)
   set_target_properties(
     minimal-cmake::game-of-life
-    PROPERTIES IMPORTED_LOCATION "${mc-gol_LIBRARY}"
+    PROPERTIES IMPORTED_IMPLIB "${mc-gol_LIBRARY}" 
+               IMPORTED_LOCATION "${mc-gol_DLL}"
                INTERFACE_INCLUDE_DIRECTORIES "${mc-gol_INCLUDE_DIR}")
 endif()

--- a/ch7/part-7/cmake/Findmc-gol.cmake
+++ b/ch7/part-7/cmake/Findmc-gol.cmake
@@ -9,22 +9,56 @@ find_library(
   NAMES game-of-life game-of-lifed
   PATHS ${mc-gol_PATH}/lib)
 
-# todo - windows only
-find_file(
-  mc-gol_DLL
-  NAMES game-of-life.dll game-of-lifed.dll
-  PATHS ${mc-gol_PATH}/bin)
+# on Windows, attempt to locate a .dll file (if the library was built as shared)
+if(WIN32)
+  find_file(
+    mc-gol_DLL
+    NAMES game-of-life.dll game-of-lifed.dll
+    PATHS ${mc-gol_PATH}/bin)
+endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(mc-gol DEFAULT_MSG mc-gol_LIBRARY mc-gol_DLL
-                                  mc-gol_INCLUDE_DIR)
+
+# handle find_package standard args (include mc-gol_DLL in the shared library
+# case on Windows)
+if(mc-gol_DLL)
+  find_package_handle_standard_args(mc-gol DEFAULT_MSG mc-gol_LIBRARY
+                                    mc-gol_INCLUDE_DIR mc-gol_DLL)
+else()
+  find_package_handle_standard_args(mc-gol DEFAULT_MSG mc-gol_LIBRARY
+                                    mc-gol_INCLUDE_DIR)
+endif()
 
 # if the library has been found, define the imported target
 if(mc-gol_FOUND AND NOT TARGET minimal-cmake::game-of-life)
-  add_library(minimal-cmake::game-of-life SHARED IMPORTED)
-  set_target_properties(
-    minimal-cmake::game-of-life
-    PROPERTIES IMPORTED_IMPLIB "${mc-gol_LIBRARY}" 
-               IMPORTED_LOCATION "${mc-gol_DLL}"
-               INTERFACE_INCLUDE_DIRECTORIES "${mc-gol_INCLUDE_DIR}")
+  if(WIN32)
+    # if a .dll file was found, reference .lib file using IMPORTED_LIB, and
+    # .dll file using IMPORTED_LOCATION, otherwise default to normal static
+    # behaviour
+    if(mc-gol_DLL)
+      add_library(minimal-cmake::game-of-life SHARED IMPORTED)
+      set_target_properties(
+        minimal-cmake::game-of-life
+        PROPERTIES IMPORTED_IMPLIB "${mc-gol_LIBRARY}"
+                   IMPORTED_LOCATION "${mc-gol_DLL}"
+                   INTERFACE_INCLUDE_DIRECTORIES "${mc-gol_INCLUDE_DIR}")
+    else()
+      add_library(minimal-cmake::game-of-life STATIC IMPORTED)
+      set_target_properties(
+        minimal-cmake::game-of-life
+        PROPERTIES IMPORTED_LOCATION "${mc-gol_LIBRARY}"
+                   INTERFACE_INCLUDE_DIRECTORIES "${mc-gol_INCLUDE_DIR}")
+    endif()
+  else()
+    cmake_path(GET mc-gol_LIBRARY EXTENSION LAST_ONLY mc-gol_LIBRARY_EXT)
+    if(${mc-gol_LIBRARY_EXT} STREQUAL ${CMAKE_SHARED_LIBRARY_SUFFIX})
+      add_library(minimal-cmake::game-of-life SHARED IMPORTED)
+    else()
+      add_library(minimal-cmake::game-of-life STATIC IMPORTED)
+    endif()
+    set_target_properties(
+      minimal-cmake::game-of-life
+      PROPERTIES IMPORTED_LOCATION "${mc-gol_LIBRARY}"
+                 INTERFACE_INCLUDE_DIRECTORIES "${mc-gol_INCLUDE_DIR}")
+  endif()
 endif()


### PR DESCRIPTION
## Summary

This change updates `Findmc-gol.cmake` to work correctly on Windows when using `minimal-cmake::game-of-life` (`mc-gol`) when it is compiled as a shared library (DLL on Windows).

The script isn't _perfect_, but it's more robust for all platforms now. Further improvements would be to distinguish DEBUG vs RELEASE versions of the libraries, but this is being intentionally omitted for now to keep the script a bit easier to parse/read for educational purposes.

Fixes https://github.com/PacktPublishing/Minimal-CMake/issues/3. Big thanks to @BCSharp for bringing it to my attention.

## Testing

This change has been built on Windows, macOS and Linux with `mc-gol` compiled as both a shared and static library.